### PR TITLE
TOOL-22966 Tweak mold repository to work with Delphix Engine

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,15 +4,15 @@ Priority: optional
 Maintainer: Sylvestre Ledru <sylvestre@debian.org>
 Build-Depends:
  cmake,
- debhelper-compat (= 13),
+ debhelper-compat (= 12),
  dwarfdump,
- libmimalloc-dev,
  libssl-dev,
  libtbb-dev,
  libxxhash-dev,
  pkg-config,
  zlib1g-dev,
- gdb
+ gdb,
+ g++-10
 Standards-Version: 4.6.0
 Homepage: https://github.com/rui314/mold
 Vcs-Browser: https://salsa.debian.org/pkg-llvm-team/mold

--- a/debian/rules
+++ b/debian/rules
@@ -12,11 +12,11 @@ export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
 # package maintainers to append LDFLAGS
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
-export SYSTEM_MIMALLOC = 1
+#export SYSTEM_MIMALLOC = 1
 #export SYSTEM_TBB = 1
 
 %:
 	dh $@
 
 override_dh_auto_configure:
-	dh_auto_configure
+	dh_auto_configure -- -DCMAKE_CXX_COMPILER=g++-10


### PR DESCRIPTION
These changes make the Ubuntu version of mold compatible with 20.04 and our specific setup. We tweak the dependency list slightly, disable a build configuration option, and force the right compiler to be used.

These changes were tested in conjunction with the appliance build and linux-pkg changes to include mold in the Delphix Engine, which have not been posted yet.